### PR TITLE
Add chirp bridge for zigbee2mqtt

### DIFF
--- a/README_ZIGBEE.md
+++ b/README_ZIGBEE.md
@@ -161,4 +161,6 @@ mosquitto_pub -h <raspberry-pi-ip> -t "zigbee2mqtt/0x00158d00053c075f/set" -m '{
 
 ## Integration with Chirp Service
 
-*Coming soon: Information about connecting Zigbee2MQTT to the Chirp bridge for enhanced functionality.*
+To connect your Zigbee2MQTT installation to the Chirp cloud service, you can use the Chirp MQTT Bridge. This bridge forwards all messages between your local Zigbee2MQTT instance and the Chirp cloud, allowing you to control your Zigbee devices remotely.
+
+For detailed installation and configuration instructions, please follow the guide in the [Chirp Bridge README](./chirp_bridge/README.md).

--- a/chirp_bridge/README.md
+++ b/chirp_bridge/README.md
@@ -1,0 +1,183 @@
+# Chirp MQTT Bridge
+
+MQTT bridge for forwarding messages between local Zigbee2MQTT and cloud MQTT server.
+
+## Description
+
+This utility creates a bidirectional bridge between a local MQTT broker connected to Zigbee2MQTT and a cloud MQTT server. This allows:
+
+- Forwarding all messages from local Zigbee2MQTT to the cloud
+- Receiving commands from the cloud and sending them to local Zigbee2MQTT
+- Providing secure connection to the cloud using TLS and authentication
+
+## Requirements
+
+- Go 1.16 or higher
+- Local MQTT broker with running Zigbee2MQTT
+- Access to a cloud MQTT server
+
+## Installation
+
+1. Copy the entire directory to your Raspberry Pi:
+
+   ```bash
+   # From your development machine, copy the entire directory
+   scp -r chirp_bridge iotmaster@192.168.0.225:/home/iotmaster/chirp_bridge
+   ```
+
+   Replace `your-raspberry-pi-ip` with your device's actual IP address.
+
+2. Compile the application:
+
+   ```bash
+   # Navigate to the project directory
+   cd ~/chirp_bridge
+   
+   # Install dependencies
+   go mod tidy
+   
+   # If you encounter network issues, try one of these alternatives:
+   # GOPROXY=https://proxy.golang.org go mod tidy
+   # or
+   # GODEBUG=netdns=cgo go mod tidy
+   
+   # Compile the application
+   go build -o chirp_bridge
+   ```
+
+## Configuration
+
+Edit the `config.yaml` file according to your settings. There are two ways to configure the local MQTT connection:
+
+### 1. Automatic Configuration
+
+The bridge can automatically read settings from your Zigbee2MQTT configuration file:
+
+```yaml
+# MQTT Bridge Configuration
+local_mqtt:
+  # Set mode to "auto" to read settings from Zigbee2MQTT configuration
+  mode: "auto"
+  # Path to Zigbee2MQTT configuration file
+  zigbee2mqtt_config_path: "/opt/zigbee2mqtt/data/configuration.yaml"
+  # The following manual settings will be ignored in auto mode
+  server: "localhost"
+  port: 1883
+  base_topic: "zigbee2mqtt"
+  username: ""  # Local MQTT username
+  password: ""  # Local MQTT password
+
+cloud_mqtt:
+  server: "example.cloud.com"  # Replace with your cloud MQTT server address
+  port: 8883
+  base_topic: "zigbee2mqtt"
+  username: "cloud_user"  # Cloud MQTT username
+```
+
+When using automatic configuration, the bridge will read the following from your Zigbee2MQTT configuration file:
+
+```yaml
+# Example Zigbee2MQTT configuration format
+version: 4
+mqtt:
+  base_topic: zigbee2mqtt
+  server: mqtt://localhost:1883
+```
+
+### 2. Manual Configuration
+
+If you prefer to set the parameters manually:
+
+```yaml
+# MQTT Bridge Configuration
+local_mqtt:
+  # Set mode to "manual" to use the settings specified below
+  mode: "manual"
+  # Path is ignored in manual mode
+  zigbee2mqtt_config_path: "/opt/zigbee2mqtt/data/configuration.yaml"
+  # Manual settings
+  server: "localhost"
+  port: 1883
+  base_topic: "zigbee2mqtt"
+  username: ""  # Local MQTT username
+  password: ""  # Local MQTT password
+
+cloud_mqtt:
+  server: "example.cloud.com"  # Replace with your cloud MQTT server address
+  port: 8883
+  base_topic: "zigbee2mqtt"
+  username: "cloud_user"  # Cloud MQTT username
+  password: "cloud_password"  # Cloud MQTT password
+  use_tls: true  # Use TLS for cloud connection
+```
+
+## Running
+
+```bash
+./chirp_bridge [path_to_config]
+```
+
+By default, the program looks for the `config.yaml` file in the current directory. You can specify a different path to the configuration file as a command line argument.
+
+## Usage
+
+After starting, the bridge automatically:
+
+1. Connects to the local MQTT broker
+2. Connects to the cloud MQTT server
+3. Starts forwarding all messages between them
+
+### Examples
+
+When a local device sends a status update:
+
+```bash
+zigbee2mqtt/0x00158d00053c075f -> cloud_server/zigbee2mqtt/0x00158d00053c075f
+```
+
+When a command is sent from the cloud:
+
+```bash
+cloud_server/zigbee2mqtt/0x00158d00053c075f/set -> zigbee2mqtt/0x00158d00053c075f/set
+```
+
+## Running as a systemd service
+
+Create a systemd service file:
+
+```bash
+sudo nano /etc/systemd/system/chirp-bridge.service
+```
+
+File contents:
+
+```ini
+[Unit]
+Description=Chirp MQTT Bridge
+After=network.target mosquitto.service
+
+[Service]
+ExecStart=/home/iotmaster/chirp_bridge/chirp_bridge /home/iotmaster/chirp_bridge/config.yaml
+WorkingDirectory=/home/iotmaster/chirp_bridge
+Restart=always
+RestartSec=10
+User=iotmaster
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Activate and start the service:
+
+```bash
+sudo systemctl enable chirp-bridge.service
+sudo systemctl start chirp-bridge.service
+```
+
+## Logging
+
+The program outputs logs to standard output. When running as a systemd service, logs can be viewed using:
+
+```bash
+sudo journalctl -u chirp-bridge.service -f
+```

--- a/chirp_bridge/config.yaml
+++ b/chirp_bridge/config.yaml
@@ -1,0 +1,22 @@
+# MQTT Bridge Configuration
+local_mqtt:
+  # Mode can be "auto" or "manual"
+  mode: "manual"
+  # Path to Zigbee2MQTT configuration file (used only if mode is "auto")
+  # zigbee2mqtt_config_path: "/opt/zigbee2mqtt/data/configuration.yaml"
+  # Manual settings (used only if mode is "manual")
+  server: "localhost"
+  port: 1883
+  base_topic: "zigbee2mqtt"
+  # Local MQTT username, if required
+  # username: ""
+  # Local MQTT password, if required
+  # password: ""
+
+cloud_mqtt:
+  server: "chirp.cloud.com"  # Replace with your cloud MQTT server address
+  port: 8883
+  base_topic: "zigbee2mqtt"
+  username: "chirp_cloud_user"  # Cloud MQTT username
+  password: "chirp_cloud_password"  # Cloud MQTT password
+  use_tls: true  # Use TLS for cloud connection

--- a/chirp_bridge/go.mod
+++ b/chirp_bridge/go.mod
@@ -1,0 +1,14 @@
+module github.com/chirpdepin/raspberry-pi-iot-hub/chirp_bridge
+
+go 1.19
+
+require (
+	github.com/eclipse/paho.mqtt.golang v1.5.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/gorilla/websocket v1.5.3 // indirect
+	golang.org/x/net v0.27.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+)

--- a/chirp_bridge/go.sum
+++ b/chirp_bridge/go.sum
@@ -1,0 +1,11 @@
+github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
+github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
+golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/chirp_bridge/main.go
+++ b/chirp_bridge/main.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"gopkg.in/yaml.v3"
+)
+
+// Config structure for storing configuration
+type Config struct {
+	LocalMQTT struct {
+		Mode                 string `yaml:"mode"`
+		Zigbee2MQTTConfigPath string `yaml:"zigbee2mqtt_config_path"`
+		Server               string `yaml:"server"`
+		Port                 int    `yaml:"port"`
+		BaseTopic            string `yaml:"base_topic"`
+		Username             string `yaml:"username"`
+		Password             string `yaml:"password"`
+	} `yaml:"local_mqtt"`
+
+	CloudMQTT struct {
+		Server    string `yaml:"server"`
+		Port      int    `yaml:"port"`
+		BaseTopic string `yaml:"base_topic"`
+		Username  string `yaml:"username"`
+		Password  string `yaml:"password"`
+		UseTLS    bool   `yaml:"use_tls"`
+	} `yaml:"cloud_mqtt"`
+}
+
+// MQTTBridge structure for storing bridge state
+type MQTTBridge struct {
+	config      Config
+	localClient mqtt.Client
+	cloudClient mqtt.Client
+}
+
+// NewMQTTBridge creates a new instance of MQTT bridge
+func NewMQTTBridge(configPath string) (*MQTTBridge, error) {
+	// Load configuration
+	config, err := loadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error loading configuration: %w", err)
+	}
+
+	bridge := &MQTTBridge{
+		config: config,
+	}
+
+	// Create local MQTT client
+	localOpts := mqtt.NewClientOptions()
+	localOpts.AddBroker(fmt.Sprintf("tcp://%s:%d", config.LocalMQTT.Server, config.LocalMQTT.Port))
+	localOpts.SetClientID("chirp_bridge_local")
+	if config.LocalMQTT.Username != "" {
+		localOpts.SetUsername(config.LocalMQTT.Username)
+		localOpts.SetPassword(config.LocalMQTT.Password)
+	}
+	localOpts.SetAutoReconnect(true)
+	localOpts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
+		log.Printf("Connection to local MQTT lost: %v", err)
+	})
+	localOpts.SetOnConnectHandler(func(client mqtt.Client) {
+		log.Println("Connected to local MQTT broker")
+	})
+
+	// Create cloud MQTT client
+	cloudOpts := mqtt.NewClientOptions()
+	protocol := "tcp"
+	if config.CloudMQTT.UseTLS {
+		protocol = "ssl"
+	}
+	cloudOpts.AddBroker(fmt.Sprintf("%s://%s:%d", protocol, config.CloudMQTT.Server, config.CloudMQTT.Port))
+	cloudOpts.SetClientID("chirp_bridge_cloud")
+	if config.CloudMQTT.Username != "" {
+		cloudOpts.SetUsername(config.CloudMQTT.Username)
+		cloudOpts.SetPassword(config.CloudMQTT.Password)
+	}
+	cloudOpts.SetAutoReconnect(true)
+	cloudOpts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
+		log.Printf("Connection to cloud MQTT lost: %v", err)
+	})
+	cloudOpts.SetOnConnectHandler(func(client mqtt.Client) {
+		log.Println("Connected to cloud MQTT broker")
+	})
+
+	// Initialize clients
+	bridge.localClient = mqtt.NewClient(localOpts)
+	bridge.cloudClient = mqtt.NewClient(cloudOpts)
+
+	return bridge, nil
+}
+
+// Start launches the MQTT bridge
+func (b *MQTTBridge) Start() error {
+	// Connect to local MQTT
+	if token := b.localClient.Connect(); token.Wait() && token.Error() != nil {
+		return fmt.Errorf("error connecting to local MQTT: %w", token.Error())
+	}
+
+	// Connect to cloud MQTT
+	if token := b.cloudClient.Connect(); token.Wait() && token.Error() != nil {
+		return fmt.Errorf("error connecting to cloud MQTT: %w", token.Error())
+	}
+
+	// Subscribe to all local zigbee2mqtt messages
+	localTopic := b.config.LocalMQTT.BaseTopic + "/#"
+	if token := b.localClient.Subscribe(localTopic, 0, b.handleLocalMessage); token.Wait() && token.Error() != nil {
+		return fmt.Errorf("error subscribing to local topic %s: %w", localTopic, token.Error())
+	}
+	log.Printf("Subscribed to local topic: %s", localTopic)
+
+	// Subscribe to all cloud zigbee2mqtt messages
+	cloudTopic := b.config.CloudMQTT.BaseTopic + "/#"
+	if token := b.cloudClient.Subscribe(cloudTopic, 0, b.handleCloudMessage); token.Wait() && token.Error() != nil {
+		return fmt.Errorf("error subscribing to cloud topic %s: %w", cloudTopic, token.Error())
+	}
+	log.Printf("Subscribed to cloud topic: %s", cloudTopic)
+
+	return nil
+}
+
+// Stop terminates the MQTT bridge
+func (b *MQTTBridge) Stop() {
+	if b.localClient != nil && b.localClient.IsConnected() {
+		b.localClient.Disconnect(250)
+	}
+	if b.cloudClient != nil && b.cloudClient.IsConnected() {
+		b.cloudClient.Disconnect(250)
+	}
+	log.Println("MQTT bridge stopped")
+}
+
+// handleLocalMessage processes messages from local MQTT and forwards them to the cloud
+func (b *MQTTBridge) handleLocalMessage(client mqtt.Client, msg mqtt.Message) {
+	// Get relative topic path
+	topic := msg.Topic()
+	relTopic := strings.TrimPrefix(topic, b.config.LocalMQTT.BaseTopic)
+
+	// Create corresponding cloud topic
+	cloudTopic := b.config.CloudMQTT.BaseTopic + relTopic
+
+	// Forward message to cloud
+	if token := b.cloudClient.Publish(cloudTopic, 0, false, msg.Payload()); token.Wait() && token.Error() != nil {
+		log.Printf("Error forwarding to cloud (topic %s): %v", cloudTopic, token.Error())
+		return
+	}
+
+	log.Printf("Forwarded to cloud: %s -> %s", topic, cloudTopic)
+}
+
+// handleCloudMessage processes messages from cloud MQTT and forwards them locally
+func (b *MQTTBridge) handleCloudMessage(client mqtt.Client, msg mqtt.Message) {
+	// Get relative topic path
+	topic := msg.Topic()
+	relTopic := strings.TrimPrefix(topic, b.config.CloudMQTT.BaseTopic)
+
+	// Create corresponding local topic
+	localTopic := b.config.LocalMQTT.BaseTopic + relTopic
+
+	// Forward message locally
+	if token := b.localClient.Publish(localTopic, 0, false, msg.Payload()); token.Wait() && token.Error() != nil {
+		log.Printf("Error forwarding locally (topic %s): %v", localTopic, token.Error())
+		return
+	}
+
+	log.Printf("Forwarded locally: %s -> %s", topic, localTopic)
+}
+
+// Zigbee2MQTTConfig represents the structure of Zigbee2MQTT configuration file
+type Zigbee2MQTTConfig struct {
+	Version int `yaml:"version"`
+	MQTT    struct {
+		BaseTopic string `yaml:"base_topic"`
+		Server    string `yaml:"server"`
+	} `yaml:"mqtt"`
+}
+
+// loadConfig loads configuration from file
+func loadConfig(configPath string) (Config, error) {
+	var config Config
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return config, fmt.Errorf("error reading configuration file: %w", err)
+	}
+
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return config, fmt.Errorf("error parsing configuration file: %w", err)
+	}
+
+	// If auto mode is enabled, load settings from Zigbee2MQTT configuration
+	if config.LocalMQTT.Mode == "auto" {
+		err = loadZigbee2MQTTConfig(&config)
+		if err != nil {
+			return config, fmt.Errorf("error loading Zigbee2MQTT configuration: %w", err)
+		}
+	}
+
+	return config, nil
+}
+
+// loadZigbee2MQTTConfig loads MQTT settings from Zigbee2MQTT configuration file
+func loadZigbee2MQTTConfig(config *Config) error {
+	if config.LocalMQTT.Zigbee2MQTTConfigPath == "" {
+		return fmt.Errorf("Zigbee2MQTT configuration path is not specified")
+	}
+
+	// Read Zigbee2MQTT configuration file
+	data, err := os.ReadFile(config.LocalMQTT.Zigbee2MQTTConfigPath)
+	if err != nil {
+		return fmt.Errorf("error reading Zigbee2MQTT configuration file: %w", err)
+	}
+
+	// Parse Zigbee2MQTT configuration
+	var z2mConfig Zigbee2MQTTConfig
+	err = yaml.Unmarshal(data, &z2mConfig)
+	if err != nil {
+		return fmt.Errorf("error parsing Zigbee2MQTT configuration file: %w", err)
+	}
+
+	// Extract MQTT server and port from the server URL
+	serverURL := z2mConfig.MQTT.Server
+	if strings.HasPrefix(serverURL, "mqtt://") {
+		serverURL = strings.TrimPrefix(serverURL, "mqtt://")
+	}
+
+	// Parse server and port
+	parts := strings.Split(serverURL, ":")
+	config.LocalMQTT.Server = parts[0]
+	if len(parts) > 1 {
+		port, err := strconv.Atoi(parts[1])
+		if err == nil {
+			config.LocalMQTT.Port = port
+		}
+	}
+
+	// Set base topic
+	config.LocalMQTT.BaseTopic = z2mConfig.MQTT.BaseTopic
+
+	log.Printf("Loaded MQTT configuration from Zigbee2MQTT: server=%s, port=%d, base_topic=%s", 
+		config.LocalMQTT.Server, config.LocalMQTT.Port, config.LocalMQTT.BaseTopic)
+
+	return nil
+}
+
+func main() {
+	log.Println("Starting Chirp Bridge MQTT Bridge")
+
+	configPath := "config.yaml"
+	if len(os.Args) > 1 {
+		configPath = os.Args[1]
+	}
+
+	// Create and start MQTT bridge
+	bridge, err := NewMQTTBridge(configPath)
+	if err != nil {
+		log.Fatalf("Error creating MQTT bridge: %v", err)
+	}
+
+	if err := bridge.Start(); err != nil {
+		log.Fatalf("Error starting MQTT bridge: %v", err)
+	}
+
+	// Wait for signal to properly terminate
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	log.Println("Termination signal received, stopping MQTT bridge...")
+	bridge.Stop()
+}


### PR DESCRIPTION
# Adding Chirp Bridge Component

## Description

Added a new `chirp_bridge` component - a bidirectional bridge for MQTT messages between local Zigbee2MQTT broker and cloud MQTT server.

## Functionality

- Forwards all messages from local Zigbee2MQTT to the cloud
- Receives commands from the cloud and sends them to local Zigbee2MQTT
- Provides secure connection to the cloud using TLS and authentication

## Technical Details

- Written in Go (requires version 1.16 or higher)
- Supports two configuration modes:
  - Automatic: reads settings from Zigbee2MQTT configuration file
  - Manual: all parameters are set manually in config.yaml
- Implemented as a systemd service

## Installation and Configuration

- Component includes complete documentation in README.md
- Sample configuration file config.yaml is provided
- Instructions for compilation, installation, and running as a system service are included

## Testing

The component has been tested on Raspberry Pi with local MQTT broker and Zigbee2MQTT.
